### PR TITLE
Rename the 'rawtext' page variable to 'header' -- see core commit f794e24

### DIFF
--- a/src/modules/Socialise/lib/Socialise/Api/Plugin.php
+++ b/src/modules/Socialise/lib/Socialise/Api/Plugin.php
@@ -166,7 +166,7 @@ class Socialise_Api_Plugin extends Zikula_AbstractApi
         // add the meta tags
         foreach (array_filter($keys) as $prop => $content) {
             if (in_array($prop, array('app_id', 'admins'))) {
-                PageUtil::addVar('rawtext', '<meta property="fb:'.$prop.'" content="'.$content.'" />');
+                PageUtil::addVar('header', '<meta property="fb:'.$prop.'" content="'.$content.'" />');
             }
         }
 
@@ -182,7 +182,7 @@ class Socialise_Api_Plugin extends Zikula_AbstractApi
             }
 
             foreach($metadata as $prop => $content ) {
-                PageUtil::addVar('rawtext', '<meta property="og:'.$prop.'" content="'.$content.'" />');
+                PageUtil::addVar('header', '<meta property="og:'.$prop.'" content="'.$content.'" />');
             }
         }
 

--- a/src/modules/Socialise/templates/plugins/function.ogtag.php
+++ b/src/modules/Socialise/templates/plugins/function.ogtag.php
@@ -45,5 +45,5 @@ function smarty_function_ogtag($params, &$view)
         return;
     }
 
-    PageUtil::addVar('rawtext', '<meta property="og:'.$params['prop'].'" content="'.$params['content'].'" />');
+    PageUtil::addVar('header', '<meta property="og:'.$params['prop'].'" content="'.$params['content'].'" />');
 }


### PR DESCRIPTION
This is for the page variable rename just committed to core. Need to use 'header' instead of 'rawtext' now.

I had your code, so it got updated when I searched through all my open projects. No sense making you do the work if it is already done.
